### PR TITLE
Add playground blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/post.php?post=4&action=edit",
+	"preferredVersions": {
+		"php": "8.1",
+		"wp": "latest"
+	},
+	"phpExtensionBundles": [
+		"kitchen-sink"
+	],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org\/plugins",
+				"slug": "jsonnorge-block"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; wp_insert_post( array('post_title'    => 'Jobbnorge','post_content'  => '<!-- wp:dss/jobbnorge {\"employerID\":\"1981,1992,1980,2770,1989,1994,1986,1984,1985,1987,1996,1988,1982,1983,1995,1993,1991\"} /-->', 'post_status'   => 'publish', 'post_author'   => 1 ) );"
+		}
+	]
+}


### PR DESCRIPTION
This pull request adds a new playground blueprint file that contains the necessary steps to set up a WordPress environment with specific plugin installation and post creation.