### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-assets-deploy.yml
+++ b/.github/workflows/manual-assets-deploy.yml
@@ -6,6 +6,8 @@ jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update


### PR DESCRIPTION
Potential fix for [https://github.com/dss-web/jobbnorge-block/security/code-scanning/2](https://github.com/dss-web/jobbnorge-block/security/code-scanning/2)

In general, this problem is fixed by explicitly defining a `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` only has the minimum scopes required. This avoids inheriting broader organization/repository defaults and documents the workflow’s needs.

For this particular workflow (`.github/workflows/manual-assets-deploy.yml`), the minimal, non-breaking fix is to add a `permissions` block under the `trunk` job. Because the 10up WordPress asset update action typically needs to interact with repository contents (and may push tag or read files), we should at least grant `contents: read`. If the action needs to push to the repo via `GITHUB_TOKEN`, it would need `contents: write`, but we cannot safely assume that without seeing more of the action’s behavior. Since your snippet only shows interaction with SVN credentials and ignores other files, a conservative and safe starting point is `contents: read`, which also satisfies the CodeQL recommendation and does not reduce functionality if the workflow only reads contents. If you later confirm that write access is required, you can adjust to `contents: write`.

Concretely:
- Edit `.github/workflows/manual-assets-deploy.yml`.
- Under `jobs: trunk:`, add a `permissions:` section between `runs-on: ubuntu-latest` and `steps:`.
- Set `contents: read` in that block.
No new imports or methods are needed, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
